### PR TITLE
Fix app crashing if the element to localize/validate doesn't have any tags

### DIFF
--- a/frontend/src/components/tagEditor/editForm.js
+++ b/frontend/src/components/tagEditor/editForm.js
@@ -91,8 +91,9 @@ const SkipDropdown = (props) => {
 };
 
 export function TagEditorForm(props) {
-  const name = props.element["tags"]["name"] ? "name" : "name:en";
-  const text = encodeURIComponent(props.element["tags"][name]);
+  const elementTags = props.element.tags ? props.element.tags : {};
+  const name = elementTags.name ? "name" : "name:en";
+  const text = encodeURIComponent(elementTags[name]);
   const elementKey = `${props.element.type}-${props.element.id}`;
   const editTags = props.tags.split(",").map((tag) => tag.trim());
   // Sort editTags array so that the order of tags is consistent
@@ -158,11 +159,7 @@ export function TagEditorForm(props) {
           >
             <div className="border border-secondary-subtle p-2 m-2 rounded">
               {editTags.map((key) => {
-                return inputComponnent(
-                  key,
-                  props.element["tags"][key],
-                  isFormDisabled
-                );
+                return inputComponnent(key, elementTags[key], isFormDisabled);
               })}
             </div>
             {isFormDisabled ? (

--- a/frontend/src/components/tagEditor/editForm.js
+++ b/frontend/src/components/tagEditor/editForm.js
@@ -8,7 +8,7 @@ import InputToolForm from "./inputToolForm";
 import TranslateComponent from "./translate";
 import { CHANGES_UPLOAD_LIMIT } from "../../config";
 
-export const inputComponnent = (key, value, disabled) => {
+export const inputComponent = (key, value, disabled) => {
   return (
     <div className="input-group input-group-sm p-2" key={key}>
       <span className="input-group-text sm" id={key}>
@@ -159,7 +159,7 @@ export function TagEditorForm(props) {
           >
             <div className="border border-secondary-subtle p-2 m-2 rounded">
               {editTags.map((key) => {
-                return inputComponnent(key, elementTags[key], isFormDisabled);
+                return inputComponent(key, elementTags[key], isFormDisabled);
               })}
             </div>
             {isFormDisabled ? (

--- a/frontend/src/views/challengeDetail.js
+++ b/frontend/src/views/challengeDetail.js
@@ -43,10 +43,10 @@ const ChallengeInfoSection = ({ challenge, height }) => {
   const maxPadding = "pt-2";
 
   const createdDate = new Date(challenge.created);
-  const formattedDate = createdDate.toLocaleDateString('en-US', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric'
+  const formattedDate = createdDate.toLocaleDateString("en-US", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
   });
 
   return (


### PR DESCRIPTION
For now the editor view will just show empty form in case of element not having tags but in the future we might need to show a modal mentioning the element doesn't have any tags. Do you want to skip this feature and mark as invalid data?